### PR TITLE
Update testserver.py IF self.path.endswith(".html")

### DIFF
--- a/pygbag/testserver.py
+++ b/pygbag/testserver.py
@@ -227,7 +227,7 @@ class CodeHandler(SimpleHTTPRequestHandler):
                     print(self.path)
                     print()
 
-            elif path.endswith(".html"):
+            elif self.path.endswith(".html"):
                 if VERB:
                     print("REPLACING", path, CDN, PROXY)
                 content = f.read()


### PR DESCRIPTION
Not to skip anytime this branch in the IF/ELIF statemements. This issue (that is a bug) was casing not properly setting for example the CORS response headers, causing issues retrieving `*.js` resources as reported here: https://github.com/pygame-web/pkg-porting-wasm/issues/3#issuecomment-1734631597