### PR TITLE
Fix Bug on iOS Devices: "Ready to Start!" Screen Unresponsive

### DIFF
--- a/static/3d.tmpl
+++ b/static/3d.tmpl
@@ -118,8 +118,15 @@ async def custom_site():
         print("""
         * Waiting for media user engagement : please click/touch page *
     """)
-        while not platform.window.MM.UME:
-            await asyncio.sleep(.1)
+        waiting = True
+        while waiting:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    exit()
+                elif event.type == pygame.MOUSEBUTTONDOWN or event.type == pygame.KEYDOWN:
+                    waiting = False
+            await asyncio.sleep(0.1)
 
     # start async top level machinery if not started and add a console in any case if requested.
     await TopLevel_async_handler.start_toplevel(platform.shell, console=window.python.config.debug)

--- a/static/default.tmpl
+++ b/static/default.tmpl
@@ -176,8 +176,15 @@ async def custom_site():
         print("""
         * Waiting for media user engagement : please click/touch page *
     """)
-        while not platform.window.MM.UME:
-            await asyncio.sleep(.1)
+        waiting = True
+        while waiting:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    exit()
+                elif event.type == pygame.MOUSEBUTTONDOWN or event.type == pygame.KEYDOWN:
+                    waiting = False
+            await asyncio.sleep(0.1)
 
     # cleanup
     screen.fill( (0,0,0,0) )

--- a/static/mobile.tmpl
+++ b/static/mobile.tmpl
@@ -194,8 +194,15 @@ async def custom_site():
 
 
     """)
-        while not platform.window.MM.UME:
-            await asyncio.sleep(.1)
+        waiting = True
+        while waiting:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    exit()
+                elif event.type == pygame.MOUSEBUTTONDOWN or event.type == pygame.KEYDOWN:
+                    waiting = False
+            await asyncio.sleep(0.1)
 
 
     # unlock async for main.py loop ( 2nd asyncio.run call )

--- a/static/noctx.tmpl
+++ b/static/noctx.tmpl
@@ -116,8 +116,15 @@ async def custom_site():
         print("""
         * Waiting for media user engagement : please click/touch page *
     """)
-        while not platform.window.MM.UME:
-            await asyncio.sleep(.1)
+        waiting = True
+        while waiting:
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    pygame.quit()
+                    exit()
+                elif event.type == pygame.MOUSEBUTTONDOWN or event.type == pygame.KEYDOWN:
+                    waiting = False
+            await asyncio.sleep(0.1)
 
     # start async top level machinery if not started and add a console in any case if requested.
     await TopLevel_async_handler.start_toplevel(platform.shell, console=window.python.config.debug)


### PR DESCRIPTION
Fixes Issue [#138](https://github.com/pygame-web/pygbag/issues/138) where the "Ready to Start!" screen is unresponsive on iOS devices. Updated the waiting loop in `custom_site()` in the template HTML files.

**Changes Made:**

- Modified the waiting loop in `custom_site()` to improve event handling on iOS devices.

**Testing:**

- Tested on one iOS device; further testing needed on other devices.