### PR TITLE
fix trailing question mark being added for GET requests without parameters

### DIFF
--- a/src/pygbag/support/cross/aio/fetch.py
+++ b/src/pygbag/support/cross/aio/fetch.py
@@ -303,7 +303,10 @@ window.Fetch.GET = function * GET (url)
         if self.is_emscripten:
             query_string = urlencode(params, doseq=doseq)
             await asyncio.sleep(0)
-            content = await platform.jsiter(platform.window.Fetch.GET(url + "?" + query_string))
+            if query_string == "":
+                content = await platform.jsiter(platform.window.Fetch.GET(url))
+            else:
+                content = await platform.jsiter(platform.window.Fetch.GET(url + "?" + query_string))
             if self.debug:
                 self.print(content)
             self.result = content


### PR DESCRIPTION
fixes a small oversight that causes any GET request that uses aio.fetch.RequestHandler to have a trailing question mark appended to it. it usually doesn't have any effect, but there are some cases where it does (e.g. the request url already has parameters).